### PR TITLE
writeValue(value): value should be NOT NULL

### DIFF
--- a/lib/src/tinymce.component.ts
+++ b/lib/src/tinymce.component.ts
@@ -140,7 +140,8 @@ export class TinymceComponent implements OnInit, AfterViewInit, OnChanges, OnDes
     }
 
     writeValue(value: string): void {
-        this.value = value;
+        // value should be NOT NULL
+        this.value = value || '';
         if (this.instance) {
             this.instance.setContent(this.value);
         }


### PR DESCRIPTION
If value is null, it may be throw an error like this:
```
TypeError: Cannot read property 'length' of undefined
    at x.setContent (tinymce.min.js:12)
    at TinymceComponent.writeValue (tinymce.component.ts:145)
    at eval (forms.js:2387)
    at eval (forms.js:3966)
    at Array.forEach (<anonymous>)
    at FormControl.setValue (forms.js:3966)
    at eval (forms.js:6256)
    at ZoneDelegate.invoke (zone.js:388)
    at Object.onInvoke (core.js:4753)
    at ZoneDelegate.invoke (zone.js:387)
    at x.setContent (tinymce.min.js:12)
    at TinymceComponent.writeValue (tinymce.component.ts:145)
```